### PR TITLE
Autoscroll (lazyLoad.pagination)

### DIFF
--- a/src/components/views/Form.vue
+++ b/src/components/views/Form.vue
@@ -406,6 +406,13 @@ export default class UserViewForm extends mixins<
     }
   }
 
+  private navigateToPage(page: number) {
+    const params = new URLSearchParams(window.location.search)
+    params.set('__p', String(page + 1))
+    const url = `${window.location.pathname}?${params.toString()}`
+    window.location.replace(url)
+  }
+
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
@@ -415,25 +422,25 @@ export default class UserViewForm extends mixins<
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
-        } else {
-          if (pagination.autoscrollRefresh) window.location.reload()
-          if (pages > 0) this.goToPage(pages - 1)
+        } else if (pages > 0) {
+          if (pagination.autoscrollRefresh) this.navigateToPage(pages - 1)
+          else this.goToPage(pages - 1)
         }
         break
 
       case 'alternate':
         if (this.autoscrollForward) {
           if (pagination.currentPage >= pages - 1 && pages > 0) {
-            if (pagination.autoscrollRefresh) window.location.reload()
             this.autoscrollForward = false
-            if (pages > 1) this.goToPrevPage()
+            if (pagination.autoscrollRefresh) this.navigateToPage(0)
+            else if (pages > 1) this.goToPrevPage()
           } else {
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
-          if (pagination.autoscrollRefresh) window.location.reload()
           this.autoscrollForward = true
-          if (pages > 1) this.goToNextPage()
+          if (pagination.autoscrollRefresh && pages > 0) this.navigateToPage(pages - 1)
+          else if (pages > 1) this.goToNextPage()
         } else {
           this.goToPrevPage()
         }
@@ -441,8 +448,8 @@ export default class UserViewForm extends mixins<
 
       default:
         if (pagination.currentPage >= pages - 1 && pages > 0) {
-          if (pagination.autoscrollRefresh) window.location.reload()
-          this.goToPage(0)
+          if (pagination.autoscrollRefresh) this.navigateToPage(0)
+          else this.goToPage(0)
         } else {
           this.goToNextPage()
         }

--- a/src/components/views/Form.vue
+++ b/src/components/views/Form.vue
@@ -416,38 +416,46 @@ export default class UserViewForm extends mixins<
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
-    const pages = this.pagesCount ?? 0  // null → 0
+    const currentPageIndex = Number.isFinite(pagination.currentPage)
+      ? Math.max(0, pagination.currentPage)
+      : 0
+    const totalPages =
+      this.pagesCount && this.pagesCount > 0
+        ? this.pagesCount
+        : currentPageIndex + 1 // keep at least the visible page
+    const lastPageIndex = totalPages > 0 ? totalPages - 1 : 0
 
     switch (pagination.autoscrollDirection) {
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
-        } else if (pages > 0) {
-          if (pagination.autoscrollRefresh) this.navigateToPage(pages - 1)
-          else this.goToPage(pages - 1)
+        } else if (totalPages > 0) {
+          if (pagination.autoscrollRefresh) this.navigateToPage(lastPageIndex)
+          else this.goToPage(lastPageIndex)
         }
         break
 
       case 'alternate':
         if (this.autoscrollForward) {
-          if (pagination.currentPage >= pages - 1 && pages > 0) {
+          if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
             this.autoscrollForward = false
             if (pagination.autoscrollRefresh) this.navigateToPage(0)
-            else if (pages > 1) this.goToPrevPage()
+            else if (totalPages > 1) this.goToPrevPage()
           } else {
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
           this.autoscrollForward = true
-          if (pagination.autoscrollRefresh && pages > 0) this.navigateToPage(pages - 1)
-          else if (pages > 1) this.goToNextPage()
+          if (pagination.autoscrollRefresh && totalPages > 0)
+            this.navigateToPage(lastPageIndex)
+          else if (totalPages > 1) this.goToNextPage()
         } else {
           this.goToPrevPage()
         }
         break
 
       default:
-        if (pagination.currentPage >= pages - 1 && pages > 0) {
+        if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
           if (pagination.autoscrollRefresh) this.navigateToPage(0)
           else this.goToPage(0)
         } else {

--- a/src/components/views/Form.vue
+++ b/src/components/views/Form.vue
@@ -409,19 +409,21 @@ export default class UserViewForm extends mixins<
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
-    const pages = this.pagesCount
+    const pages = this.pagesCount ?? 0  // null → 0
+
     switch (pagination.autoscrollDirection) {
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
         } else {
           if (pagination.autoscrollRefresh) window.location.reload()
-          if (pages && pages > 0) this.goToPage(pages - 1)
+          if (pages > 0) this.goToPage(pages - 1)
         }
         break
+
       case 'alternate':
         if (this.autoscrollForward) {
-          if (pages !== null && pagination.currentPage >= pages - 1) {
+          if (pagination.currentPage >= pages - 1 && pages > 0) {
             if (pagination.autoscrollRefresh) window.location.reload()
             this.autoscrollForward = false
             if (pages > 1) this.goToPrevPage()
@@ -429,15 +431,16 @@ export default class UserViewForm extends mixins<
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
-            if (pagination.autoscrollRefresh) window.location.reload()
-            this.autoscrollForward = true
-            if (pages > 1) this.goToNextPage()
-          } else {
-            this.goToPrevPage()
-          }
+          if (pagination.autoscrollRefresh) window.location.reload()
+          this.autoscrollForward = true
+          if (pages > 1) this.goToNextPage()
+        } else {
+          this.goToPrevPage()
+        }
         break
+
       default:
-        if (pages !== null && pagination.currentPage >= pages - 1) {
+        if (pagination.currentPage >= pages - 1 && pages > 0) {
           if (pagination.autoscrollRefresh) window.location.reload()
           this.goToPage(0)
         } else {
@@ -445,6 +448,7 @@ export default class UserViewForm extends mixins<
         }
     }
   }
+
 
   private setupAutoscroll() {
     if (this.autoscrollTimer !== null) {

--- a/src/components/views/Table.vue
+++ b/src/components/views/Table.vue
@@ -1877,38 +1877,46 @@ export default class UserViewTable extends mixins<
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
-    const pages = this.pagesCount ?? 0  // null → 0
+    const currentPageIndex = Number.isFinite(pagination.currentPage)
+      ? Math.max(0, pagination.currentPage)
+      : 0
+    const totalPages =
+      this.pagesCount && this.pagesCount > 0
+        ? this.pagesCount
+        : currentPageIndex + 1 // keep at least the visible page
+    const lastPageIndex = totalPages > 0 ? totalPages - 1 : 0
 
     switch (pagination.autoscrollDirection) {
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
-        } else if (pages > 0) {
-          if (pagination.autoscrollRefresh) this.navigateToPage(pages - 1)
-          else this.goToPage(pages - 1)
+        } else if (totalPages > 0) {
+          if (pagination.autoscrollRefresh) this.navigateToPage(lastPageIndex)
+          else this.goToPage(lastPageIndex)
         }
         break
 
       case 'alternate':
         if (this.autoscrollForward) {
-          if (pagination.currentPage >= pages - 1 && pages > 0) {
+          if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
             this.autoscrollForward = false
             if (pagination.autoscrollRefresh) this.navigateToPage(0)
-            else if (pages > 1) this.goToPrevPage()
+            else if (totalPages > 1) this.goToPrevPage()
           } else {
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
           this.autoscrollForward = true
-          if (pagination.autoscrollRefresh && pages > 0) this.navigateToPage(pages - 1)
-          else if (pages > 1) this.goToNextPage()
+          if (pagination.autoscrollRefresh && totalPages > 0)
+            this.navigateToPage(lastPageIndex)
+          else if (totalPages > 1) this.goToNextPage()
         } else {
           this.goToPrevPage()
         }
         break
 
       default:
-        if (pagination.currentPage >= pages - 1 && pages > 0) {
+        if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
           if (pagination.autoscrollRefresh) this.navigateToPage(0)
           else this.goToPage(0)
         } else {

--- a/src/components/views/Table.vue
+++ b/src/components/views/Table.vue
@@ -1867,6 +1867,13 @@ export default class UserViewTable extends mixins<
     }
   }
 
+  private navigateToPage(page: number) {
+    const params = new URLSearchParams(window.location.search)
+    params.set('__p', String(page + 1))
+    const url = `${window.location.pathname}?${params.toString()}`
+    window.location.replace(url)
+  }
+
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
@@ -1876,25 +1883,25 @@ export default class UserViewTable extends mixins<
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
-        } else {
-          if (pagination.autoscrollRefresh) window.location.reload()
-          if (pages > 0) this.goToPage(pages - 1)
+        } else if (pages > 0) {
+          if (pagination.autoscrollRefresh) this.navigateToPage(pages - 1)
+          else this.goToPage(pages - 1)
         }
         break
 
       case 'alternate':
         if (this.autoscrollForward) {
           if (pagination.currentPage >= pages - 1 && pages > 0) {
-            if (pagination.autoscrollRefresh) window.location.reload()
             this.autoscrollForward = false
-            if (pages > 1) this.goToPrevPage()
+            if (pagination.autoscrollRefresh) this.navigateToPage(0)
+            else if (pages > 1) this.goToPrevPage()
           } else {
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
-          if (pagination.autoscrollRefresh) window.location.reload()
           this.autoscrollForward = true
-          if (pages > 1) this.goToNextPage()
+          if (pagination.autoscrollRefresh && pages > 0) this.navigateToPage(pages - 1)
+          else if (pages > 1) this.goToNextPage()
         } else {
           this.goToPrevPage()
         }
@@ -1902,8 +1909,8 @@ export default class UserViewTable extends mixins<
 
       default:
         if (pagination.currentPage >= pages - 1 && pages > 0) {
-          if (pagination.autoscrollRefresh) window.location.reload()
-          this.goToPage(0)
+          if (pagination.autoscrollRefresh) this.navigateToPage(0)
+          else this.goToPage(0)
         } else {
           this.goToNextPage()
         }

--- a/src/components/views/Table.vue
+++ b/src/components/views/Table.vue
@@ -1964,16 +1964,23 @@ export default class UserViewTable extends mixins<
   private get currentRows() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return ''
 
-    const fromRow =
-      this.uv.extra.lazyLoad.pagination.currentPage *
-        this.uv.extra.lazyLoad.pagination.perPage +
-      1
-    const toRow =
-      (this.uv.extra.lazyLoad.pagination.currentPage + 1) *
-      this.uv.extra.lazyLoad.pagination.perPage
-    const rowCount = this.uv.rowLoadState.complete
-      ? ` ${this.$t('of').toString()} ${this.uv.rowLoadState.fetchedRowCount}`
-      : ''
+    const { perPage, currentPage } = this.uv.extra.lazyLoad.pagination
+    let fromRow = currentPage * perPage + 1
+    let toRow = (currentPage + 1) * perPage
+    let rowCount = ''
+
+    if (this.uv.rowLoadState.complete) {
+      const total = this.uv.rowLoadState.fetchedRowCount
+      if (total === 0) {
+        fromRow = 0
+        toRow = 0
+      } else {
+        toRow = Math.min(toRow, total)
+        if (fromRow > toRow) fromRow = Math.max(1, toRow)
+      }
+      rowCount = ` ${this.$t('of').toString()} ${total}`
+    }
+
     return `${fromRow}-${toRow}${rowCount}`
   }
 

--- a/src/components/views/Table.vue
+++ b/src/components/views/Table.vue
@@ -1870,19 +1870,21 @@ export default class UserViewTable extends mixins<
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
-    const pages = this.pagesCount
+    const pages = this.pagesCount ?? 0  // null → 0
+
     switch (pagination.autoscrollDirection) {
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
         } else {
           if (pagination.autoscrollRefresh) window.location.reload()
-          if (pages && pages > 0) this.goToPage(pages - 1)
+          if (pages > 0) this.goToPage(pages - 1)
         }
         break
+
       case 'alternate':
         if (this.autoscrollForward) {
-          if (pages !== null && pagination.currentPage >= pages - 1) {
+          if (pagination.currentPage >= pages - 1 && pages > 0) {
             if (pagination.autoscrollRefresh) window.location.reload()
             this.autoscrollForward = false
             if (pages > 1) this.goToPrevPage()
@@ -1890,15 +1892,16 @@ export default class UserViewTable extends mixins<
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
-            if (pagination.autoscrollRefresh) window.location.reload()
-            this.autoscrollForward = true
-            if (pages > 1) this.goToNextPage()
-          } else {
-            this.goToPrevPage()
-          }
+          if (pagination.autoscrollRefresh) window.location.reload()
+          this.autoscrollForward = true
+          if (pages > 1) this.goToNextPage()
+        } else {
+          this.goToPrevPage()
+        }
         break
+
       default:
-        if (pages !== null && pagination.currentPage >= pages - 1) {
+        if (pagination.currentPage >= pages - 1 && pages > 0) {
           if (pagination.autoscrollRefresh) window.location.reload()
           this.goToPage(0)
         } else {
@@ -1906,6 +1909,7 @@ export default class UserViewTable extends mixins<
         }
     }
   }
+
 
   private setupAutoscroll() {
     if (this.autoscrollTimer !== null) {

--- a/src/components/views/Table.vue
+++ b/src/components/views/Table.vue
@@ -1877,46 +1877,65 @@ export default class UserViewTable extends mixins<
   private handleAutoscroll() {
     if (this.uv.extra.lazyLoad.type !== 'pagination') return
     const pagination = this.uv.extra.lazyLoad.pagination
-    const currentPageIndex = Number.isFinite(pagination.currentPage)
-      ? Math.max(0, pagination.currentPage)
-      : 0
-    const totalPages =
-      this.pagesCount && this.pagesCount > 0
-        ? this.pagesCount
-        : currentPageIndex + 1 // keep at least the visible page
-    const lastPageIndex = totalPages > 0 ? totalPages - 1 : 0
+    const isComplete = this.uv.rowLoadState.complete
+    const fetchedRowCount = this.uv.rowLoadState.fetchedRowCount
+    const knownPages = this.pagesCount
+    const effectivePages =
+      knownPages !== null
+        ? knownPages
+        : isComplete
+          ? Math.max(
+              Math.ceil(fetchedRowCount / pagination.perPage),
+              0,
+            )
+          : null
+    const hasKnownPages = effectivePages !== null
+    const lastPageIndex =
+      hasKnownPages && effectivePages! > 0 ? effectivePages! - 1 : 0
+    const canStepForward =
+      !isComplete ||
+      !hasKnownPages ||
+      pagination.currentPage < lastPageIndex
+    const hasMultiplePages =
+      hasKnownPages && effectivePages! > 1
+    const hasLastPage = hasKnownPages && effectivePages! > 0
 
     switch (pagination.autoscrollDirection) {
       case 'backward':
         if (pagination.currentPage > 0) {
           this.goToPrevPage()
-        } else if (totalPages > 0) {
+        } else if (hasLastPage) {
           if (pagination.autoscrollRefresh) this.navigateToPage(lastPageIndex)
           else this.goToPage(lastPageIndex)
+        } else if (pagination.autoscrollRefresh) {
+          this.navigateToPage(0)
         }
         break
 
       case 'alternate':
         if (this.autoscrollForward) {
-          if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
+          if (!canStepForward) {
             this.autoscrollForward = false
             if (pagination.autoscrollRefresh) this.navigateToPage(0)
-            else if (totalPages > 1) this.goToPrevPage()
+            else if (hasMultiplePages) this.goToPrevPage()
           } else {
             this.goToNextPage()
           }
         } else if (pagination.currentPage <= 0) {
           this.autoscrollForward = true
-          if (pagination.autoscrollRefresh && totalPages > 0)
-            this.navigateToPage(lastPageIndex)
-          else if (totalPages > 1) this.goToNextPage()
+          if (pagination.autoscrollRefresh) {
+            if (hasLastPage) this.navigateToPage(lastPageIndex)
+            else this.navigateToPage(0)
+          } else if (hasMultiplePages) {
+            this.goToNextPage()
+          }
         } else {
           this.goToPrevPage()
         }
         break
 
       default:
-        if (pagination.currentPage >= lastPageIndex && totalPages > 0) {
+        if (!canStepForward) {
           if (pagination.autoscrollRefresh) this.navigateToPage(0)
           else this.goToPage(0)
         } else {


### PR DESCRIPTION
Overview
- Adds pagination autoscroll for tables and forms that use lazy loading.
- Extends the zod schema to accept new autoscroll fields.
- Implements three modes: forward, backward, and alternate.
- Supports optional page refresh at boundaries via URL parameter updates.
- Ensures timers are cleared when components are destroyed.

How to configure
1. Provide the new options in `lazyLoad.pagination`:
   - `autoscroll_seconds` — interval (seconds) between page switches (>0 enables autoscroll).
   - `autoscroll_direction` — `forward`, `backward`, or `alternate` (`forward` by default).
   - `autoscroll_refresh` — set to `true` to force a page reload at the boundary (uses `window.location.replace`).
2. The client consumes these parameters and starts the autoscroll timer automatically.
3. Autoscroll updates the `__p` query param, so manual navigation stays consistent with the current page.
4. When a component unmounts or the view mode changes, timers are cleared to avoid leaks.
